### PR TITLE
Add simple admin features and theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,35 @@
-# Simple Markdown Blog
+# Flask Markdown 博客
 
-This project is a minimal blog system written in Python using Flask.
-It supports writing posts in Markdown and renders them with a clean
-Bulma-based user interface.
+这是一个使用 Flask 构建的简易博客系统，支持 Markdown 撰写文章，并提供明亮/暗色主题切换。系统包含基本的文章管理、分类和标签功能，同时提供简单的后台登录。
 
-## Features
+## 功能
 
-- Create, edit, and view blog posts
-- Posts written in Markdown
-- SQLite database
-- Responsive, modern design using Bulma CSS
+- 创建、编辑和查看文章
+- Markdown 实时预览，支持代码高亮
+- 文章分类与标签
+- 简单的密码登录保护后台
+- 明亮和暗色主题切换
+- 自动生成 `sitemap.xml` 和 `rss.xml`
 
-## Setup
+## 安装与运行
 
-1. Create a virtual environment (optional but recommended):
+1. **创建虚拟环境（推荐）**
    ```bash
    python3 -m venv venv
    source venv/bin/activate
    ```
-2. Install dependencies:
+2. **安装依赖**
    ```bash
    pip install -r requirements.txt
    ```
-3. Run the application:
+3. **运行应用**
    ```bash
    python app.py
    ```
-   The blog will be available at `http://localhost:5000`.
+   默认情况下博客会运行在 `http://localhost:5000`。
 
-## Notes
+默认管理员密码可通过环境变量 `ADMIN_PASSWORD` 设置（默认为 `password`）。
 
-This is a simple demo application. It does not include authentication
-or advanced features, but serves as a foundation for a lightweight blog
-system that renders Markdown content with a pleasant aesthetic.
+## 备注
+
+此项目适合作为个人博客或学习 Flask 的示例，功能简单，可在此基础上继续扩展。

--- a/app.py
+++ b/app.py
@@ -1,4 +1,5 @@
-from flask import Flask, render_template, request, redirect, url_for
+import os
+from flask import Flask, render_template, request, redirect, url_for, session
 from flask_sqlalchemy import SQLAlchemy
 from datetime import datetime
 import markdown
@@ -6,12 +7,16 @@ import markdown
 app = Flask(__name__)
 app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///blog.db'
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+app.secret_key = os.environ.get('SECRET_KEY', 'changeme')
+ADMIN_PASSWORD = os.environ.get('ADMIN_PASSWORD', 'password')
 
 db = SQLAlchemy(app)
 
 class Post(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     title = db.Column(db.String(200), nullable=False)
+    category = db.Column(db.String(50), nullable=True)
+    tags = db.Column(db.String(200), nullable=True)
     content = db.Column(db.Text, nullable=False)
     created = db.Column(db.DateTime, default=datetime.utcnow)
 
@@ -22,10 +27,33 @@ class Post(db.Model):
 def init_db():
     db.create_all()
 
+def login_required(func):
+    from functools import wraps
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        if not session.get('logged_in'):
+            return redirect(url_for('login', next=request.path))
+        return func(*args, **kwargs)
+    return wrapper
+
 @app.route('/')
 def index():
     posts = Post.query.order_by(Post.created.desc()).all()
     return render_template('index.html', title='Home', posts=posts)
+
+@app.route('/login', methods=['GET', 'POST'])
+def login():
+    if request.method == 'POST':
+        if request.form.get('password') == ADMIN_PASSWORD:
+            session['logged_in'] = True
+            next_page = request.args.get('next') or url_for('index')
+            return redirect(next_page)
+    return render_template('login.html', title='Login')
+
+@app.route('/logout')
+def logout():
+    session.pop('logged_in', None)
+    return redirect(url_for('index'))
 
 @app.route('/post/<int:post_id>')
 def post(post_id):
@@ -33,25 +61,41 @@ def post(post_id):
     return render_template('post.html', title=post.title, post=post)
 
 @app.route('/create', methods=['GET', 'POST'])
+@login_required
 def create():
     if request.method == 'POST':
         title = request.form['title']
         content = request.form['content']
-        new_post = Post(title=title, content=content)
+        category = request.form.get('category')
+        tags = request.form.get('tags')
+        new_post = Post(title=title, content=content, category=category, tags=tags)
         db.session.add(new_post)
         db.session.commit()
         return redirect(url_for('index'))
     return render_template('create.html', title='New Post', post=None)
 
 @app.route('/edit/<int:post_id>', methods=['GET', 'POST'])
+@login_required
 def edit(post_id):
     post = Post.query.get_or_404(post_id)
     if request.method == 'POST':
         post.title = request.form['title']
         post.content = request.form['content']
+        post.category = request.form.get('category')
+        post.tags = request.form.get('tags')
         db.session.commit()
         return redirect(url_for('post', post_id=post.id))
     return render_template('create.html', title='Edit Post', post=post)
+
+@app.route('/sitemap.xml')
+def sitemap():
+    posts = Post.query.order_by(Post.created.desc()).all()
+    return render_template('sitemap.xml', posts=posts), 200, {'Content-Type': 'application/xml'}
+
+@app.route('/rss.xml')
+def rss():
+    posts = Post.query.order_by(Post.created.desc()).all()
+    return render_template('rss.xml', posts=posts), 200, {'Content-Type': 'application/rss+xml'}
 
 if __name__ == '__main__':
     with app.app_context():

--- a/static/style.css
+++ b/static/style.css
@@ -1,3 +1,12 @@
 .content img {
   max-width: 100%;
 }
+
+body.dark {
+  background-color: #121212;
+  color: #eee;
+}
+
+body.dark a {
+  color: #90caf9;
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -6,13 +6,44 @@
   <title>{{ title }} - Markdown Blog</title>
   <link href="https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css" rel="stylesheet">
   <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+  <meta name="description" content="A simple markdown blog">
 </head>
-<body>
+<body class="has-background-white">
   <section class="section">
     <div class="container">
-      <h1 class="title"><a href="{{ url_for('index') }}">Markdown Blog</a></h1>
+      <nav class="level mb-4">
+        <div class="level-left">
+          <div class="level-item">
+            <h1 class="title mb-0"><a href="{{ url_for('index') }}">Markdown Blog</a></h1>
+          </div>
+        </div>
+        <div class="level-right">
+          <div class="level-item">
+            <button id="theme-toggle" class="button is-small">Toggle Theme</button>
+          </div>
+          <div class="level-item">
+            {% if session.get('logged_in') %}
+              <a class="button is-light is-small" href="{{ url_for('logout') }}">Logout</a>
+            {% else %}
+              <a class="button is-light is-small" href="{{ url_for('login') }}">Login</a>
+            {% endif %}
+          </div>
+        </div>
+      </nav>
       {% block content %}{% endblock %}
     </div>
   </section>
+  <script>
+    const toggleBtn = document.getElementById('theme-toggle');
+    if (toggleBtn) {
+      toggleBtn.addEventListener('click', () => {
+        document.body.classList.toggle('dark');
+        localStorage.setItem('theme', document.body.classList.contains('dark') ? 'dark' : 'light');
+      });
+      if (localStorage.getItem('theme') === 'dark') {
+        document.body.classList.add('dark');
+      }
+    }
+  </script>
 </body>
 </html>

--- a/templates/create.html
+++ b/templates/create.html
@@ -10,10 +10,26 @@
     </div>
   </div>
   <div class="field">
+    <label class="label">Category</label>
+    <div class="control">
+      <input class="input" type="text" name="category" value="{{ post.category if post else '' }}">
+    </div>
+  </div>
+  <div class="field">
+    <label class="label">Tags (comma separated)</label>
+    <div class="control">
+      <input class="input" type="text" name="tags" value="{{ post.tags if post else '' }}">
+    </div>
+  </div>
+  <div class="field">
     <label class="label">Content (Markdown)</label>
     <div class="control">
-      <textarea class="textarea" name="content" rows="10" required>{{ post.content if post else '' }}</textarea>
+      <textarea class="textarea" id="md-input" name="content" rows="10" required>{{ post.content if post else '' }}</textarea>
     </div>
+  </div>
+  <div class="field">
+    <label class="label">Preview</label>
+    <div class="content box" id="preview"></div>
   </div>
   <div class="field">
     <div class="control">
@@ -21,4 +37,14 @@
     </div>
   </div>
 </form>
+<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+<script>
+  const input = document.getElementById('md-input');
+  const preview = document.getElementById('preview');
+  function update() {
+    preview.innerHTML = marked.parse(input.value);
+  }
+  input.addEventListener('input', update);
+  update();
+</script>
 {% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,11 +1,17 @@
 {% extends 'base.html' %}
 {% block content %}
+{% if session.get('logged_in') %}
 <a class="button is-primary" href="{{ url_for('create') }}">New Post</a>
+{% endif %}
 <hr>
 {% for post in posts %}
   <div class="box">
     <h2 class="title is-4"><a href="{{ url_for('post', post_id=post.id) }}">{{ post.title }}</a></h2>
-    <p class="is-size-7 has-text-grey">{{ post.created.strftime('%Y-%m-%d %H:%M') }}</p>
+    <p class="is-size-7 has-text-grey">
+      {{ post.created.strftime('%Y-%m-%d %H:%M') }}
+      {% if post.category %}| {{ post.category }}{% endif %}
+      {% if post.tags %}| {{ post.tags }}{% endif %}
+    </p>
     <div class="content">{{ post.html|safe }}</div>
   </div>
 {% else %}

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,16 @@
+{% extends 'base.html' %}
+{% block content %}
+<form method="post" class="box" style="max-width:400px;margin:auto;">
+  <div class="field">
+    <label class="label">Password</label>
+    <div class="control">
+      <input class="input" type="password" name="password" required>
+    </div>
+  </div>
+  <div class="field">
+    <div class="control">
+      <button class="button is-link" type="submit">Login</button>
+    </div>
+  </div>
+</form>
+{% endblock %}

--- a/templates/post.html
+++ b/templates/post.html
@@ -3,6 +3,13 @@
 <a href="{{ url_for('index') }}">Back to Home</a>
 <hr>
 <h2 class="title is-3">{{ post.title }}</h2>
-<p class="is-size-7 has-text-grey">{{ post.created.strftime('%Y-%m-%d %H:%M') }}</p>
+<p class="is-size-7 has-text-grey">
+  {{ post.created.strftime('%Y-%m-%d %H:%M') }}
+  {% if post.category %}| {{ post.category }}{% endif %}
+  {% if post.tags %}| {{ post.tags }}{% endif %}
+</p>
+{% if session.get('logged_in') %}
+<p><a href="{{ url_for('edit', post_id=post.id) }}">Edit</a></p>
+{% endif %}
 <div class="content">{{ post.html|safe }}</div>
 {% endblock %}

--- a/templates/rss.xml
+++ b/templates/rss.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+<channel>
+  <title>Markdown Blog</title>
+  <link>{{ url_for('index', _external=True) }}</link>
+  <description>RSS Feed</description>
+  {% for post in posts %}
+  <item>
+    <title>{{ post.title }}</title>
+    <link>{{ url_for('post', post_id=post.id, _external=True) }}</link>
+    <pubDate>{{ post.created.strftime('%a, %d %b %Y %H:%M:%S +0000') }}</pubDate>
+    <description><![CDATA[{{ post.html|safe }}]]></description>
+  </item>
+  {% endfor %}
+</channel>
+</rss>

--- a/templates/sitemap.xml
+++ b/templates/sitemap.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+{% for post in posts %}
+  <url>
+    <loc>{{ url_for('post', post_id=post.id, _external=True) }}</loc>
+    <lastmod>{{ post.created.strftime('%Y-%m-%d') }}</lastmod>
+  </url>
+{% endfor %}
+</urlset>


### PR DESCRIPTION
## Summary
- add admin login via password and session
- support categories and tags for posts
- implement dark/light theme toggle with Bulma
- add Markdown preview with marked.js
- generate sitemap and RSS feed
- document features and usage in Chinese README

## Testing
- `python -m py_compile app.py`
- `python app.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_b_686f0e6ff8748333ab7a4978115e041d