### PR TITLE
Add Vue + PHP sample with Sakura theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,7 @@
 ## 备注
 
 此项目适合作为个人博客或学习 Flask 的示例，功能简单，可在此基础上继续扩展。
+
+## Vue + PHP 示例
+
+目录 `php_backend` 与 `frontend` 提供了一个使用 Vue 结合 PHP 的简易示例，前端样式基于 [Sakura](https://github.com/mashirozx/Sakura) 主题。运行 PHP 服务器后访问 `php_backend/index.php` 即可看到效果。

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,0 +1,12 @@
+new Vue({
+  el: '#app',
+  data: {
+    message: 'Sakura Theme Blog',
+    posts: []
+  },
+  created() {
+    fetch('../php_backend/api.php')
+      .then(response => response.json())
+      .then(data => { this.posts = data });
+  }
+});

--- a/php_backend/api.php
+++ b/php_backend/api.php
@@ -1,0 +1,4 @@
+<?php
+header('Content-Type: application/json');
+$posts = json_decode(file_get_contents(__DIR__ . '/posts.json'), true);
+echo json_encode($posts);

--- a/php_backend/index.php
+++ b/php_backend/index.php
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <title>Vue PHP Blog</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/mashirozx/Sakura@3.x/style.css">
+</head>
+<body>
+  <div id="app" class="layout">
+    <h1>{{ message }}</h1>
+    <ul>
+      <li v-for="post in posts" :key="post.id">
+        <h2>{{ post.title }}</h2>
+        <p>{{ post.content }}</p>
+      </li>
+    </ul>
+  </div>
+  <script src="https://cdn.jsdelivr.net/npm/vue@2.7.16/dist/vue.js"></script>
+  <script src="../frontend/app.js"></script>
+</body>
+</html>

--- a/php_backend/posts.json
+++ b/php_backend/posts.json
@@ -1,0 +1,4 @@
+[
+  {"id": 1, "title": "Hello World", "content": "Welcome to the blog"},
+  {"id": 2, "title": "Second Post", "content": "More content here"}
+]


### PR DESCRIPTION
## Summary
- add PHP backend and Vue frontend folders
- use Sakura theme via CDN in PHP index
- fetch posts from simple PHP API
- document new example in README

## Testing
- `python -m py_compile app.py`
- `php -l php_backend/api.php`
- `php -l php_backend/index.php`
- `sudo apt-get install -y php-cli`

------
https://chatgpt.com/codex/tasks/task_b_686f1ca0699483338d18d1b2dd5a6889